### PR TITLE
Large set of breaking changes

### DIFF
--- a/src/Engine/GlobalKeyCooldown.java
+++ b/src/Engine/GlobalKeyCooldown.java
@@ -1,0 +1,76 @@
+package Engine;
+
+import Utils.Stopwatch;
+
+public class GlobalKeyCooldown {
+    public static final KeyLocker GLOBAL_KEY_LOCKER = new KeyLocker();
+    public Stopwatch stopwatch;
+    public Key key;
+
+    public GlobalKeyCooldown(Key key) {
+        this.key = key;
+        this.stopwatch = new Stopwatch();
+        this.stopwatch.setWaitTime(0);
+        this.stopwatch.reset();
+    }
+
+    public boolean isLocked() {
+        if (this.stopwatch.isTimeUp() && !GLOBAL_KEY_LOCKER.isKeyLocked(this.key)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean isDown() {
+        return Keyboard.isKeyDown(this.key);
+    }
+
+    public boolean isUp() {
+        return Keyboard.isKeyUp(this.key);
+    }
+
+    /**
+     * Try and start the lock timer, return true if we did, false if it was already going.
+     * @return true
+     */
+    public boolean timeLock() {
+        if (this.stopwatch.isTimeUp()) {
+            this.stopwatch.setWaitTime(150);
+            this.stopwatch.reset();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the key is locked; if not, and it is down, "lock" the key (actually start the timer) and return true.
+     * Else return false.
+     * 
+     * This can check if a key is pressed with a global cooldown.
+     */
+    public boolean onceDown() {
+        return this.isDown() && this.timeLock();
+    }
+
+    /**
+     * Cancel the cooldown if the key is up
+     * @return true if the key was up, regardless of whether there was a cooldown or not
+     */
+    public boolean cancelIfUp() {
+        if (this.isUp()) {
+            this.stopwatch.setWaitTime(0); // end immediately
+            this.stopwatch.reset();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static class Keys {
+        public static final GlobalKeyCooldown SPACE = new GlobalKeyCooldown(Key.SPACE);
+        public static final GlobalKeyCooldown UP = new GlobalKeyCooldown(Key.UP);
+        public static final GlobalKeyCooldown DOWN = new GlobalKeyCooldown(Key.DOWN);
+    }
+}

--- a/src/Game/GameState.java
+++ b/src/Game/GameState.java
@@ -1,8 +1,0 @@
-package Game;
-
-/*
- * This is used by the ScreenCoordinator class to determine which "state" the game is currently in
- */
-public enum GameState {
-    MENU, LEVEL, CREDITS, HOUSE, CONTROLS, STACK
-}

--- a/src/Game/GameState.java
+++ b/src/Game/GameState.java
@@ -4,5 +4,5 @@ package Game;
  * This is used by the ScreenCoordinator class to determine which "state" the game is currently in
  */
 public enum GameState {
-    MENU, LEVEL, CREDITS, HOUSE, CONTROLS
+    MENU, LEVEL, CREDITS, HOUSE, CONTROLS, STACK
 }

--- a/src/Game/ScreenCoordinator.java
+++ b/src/Game/ScreenCoordinator.java
@@ -107,7 +107,7 @@ public class ScreenCoordinator extends Screen {
 	}
 
 	private void debugPrintStack(String s) {
-		if (false) {
+		if (true) { // debug output disabled
 			return;
 		}
 

--- a/src/Game/ScreenCoordinator.java
+++ b/src/Game/ScreenCoordinator.java
@@ -1,5 +1,7 @@
 package Game;
 
+import java.util.ArrayDeque;
+
 import Engine.DefaultScreen;
 import Engine.GraphicsHandler;
 import Engine.Screen;
@@ -61,7 +63,10 @@ public class ScreenCoordinator extends Screen {
 						currentScreen = new ControlsScreen(this);
 						break;
 				}
-				currentScreen.initialize();
+
+				if (gameState != GameState.STACK) {
+					currentScreen.initialize();
+				}
 			}
 			previousGameState = gameState;
 
@@ -75,4 +80,48 @@ public class ScreenCoordinator extends Screen {
 		// call the draw method for the currentScreen
 		currentScreen.draw(graphicsHandler);
 	}
+
+	public PlayLevelScreen getPlayLevelScreen() {
+		return playLevelScreen;
+	}
+
+	/* RECURSIVE FUNCTIONALITY BELOW @author hle0 */
+
+	protected static class StackFrame {
+        public GameState state;
+        public Screen screen;
+
+        public StackFrame(GameState state, Screen screen) {
+            this.state = state;
+            this.screen = screen;
+        }
+    }
+	
+    protected ArrayDeque<StackFrame> stack = new ArrayDeque<>();
+
+    public void push(Screen screen) {
+        this.stack.push(new StackFrame(this.gameState, this.currentScreen));
+
+        this.gameState = GameState.STACK;
+        this.currentScreen = screen;
+		this.currentScreen.initialize();
+    }
+
+    protected void drop() {
+        StackFrame frame = this.stack.pop();
+
+        this.gameState = frame.state;
+        this.currentScreen = frame.screen;
+    }
+
+    public void pop(Screen screen) {
+        if (this.currentScreen != screen) {
+            System.err.println("Warning; tried to pop a screen that wasn't the top screen.");
+            while (this.currentScreen != screen) {
+                this.drop();
+            }
+        }
+        
+        this.drop();
+    }
 }

--- a/src/Game/ScreenCoordinator.java
+++ b/src/Game/ScreenCoordinator.java
@@ -1,17 +1,12 @@
 package Game;
 
 import java.util.ArrayDeque;
+import java.util.List;
 
 import Engine.DefaultScreen;
 import Engine.GraphicsHandler;
 import Engine.Screen;
-import Game.GameState;
-import Level.PlayerInventory;
-import Screens.CreditsScreen;
-import Screens.HouseScreen;
-import Screens.ControlsScreen;
 import Screens.MenuScreen;
-import Screens.PauseScreen;
 import Screens.PlayLevelScreen;
 
 /*
@@ -22,57 +17,19 @@ public class ScreenCoordinator extends Screen {
 	// currently shown Screen
 	protected Screen currentScreen = new DefaultScreen();
 	protected PlayLevelScreen playLevelScreen;
-
-	// keep track of gameState so ScreenCoordinator knows which Screen to show
-	protected GameState gameState;
-	protected GameState previousGameState;
-	
-
-	public GameState getGameState() {
-		return gameState;
-	}
-
-	// Other Screens can set the gameState of this class to force it to change the currentScreen
-	public void setGameState(GameState gameState) {
-		this.gameState = gameState;
-	}
+	public MenuScreen mainMenuScreen;
 
 	@Override
 	public void initialize() {
 		// start game off with Menu Screen
-		gameState = GameState.MENU;
+		mainMenuScreen = new MenuScreen(this);
+		mainMenuScreen.initialize();
+		this.currentScreen = mainMenuScreen;
 	}
 
 	@Override
 	public void update() {
-		do {
-			// if previousGameState does not equal gameState, it means there was a change in gameState
-			// this triggers ScreenCoordinator to bring up a new Screen based on what the gameState is
-			if (previousGameState != gameState) {
-				switch(gameState) {
-					case MENU:
-						currentScreen = new MenuScreen(this);
-						break;
-					case LEVEL:
-						currentScreen = new PlayLevelScreen(this);
-						break;
-					case CREDITS:
-						currentScreen = new CreditsScreen(this);
-						break;
-					case CONTROLS:
-						currentScreen = new ControlsScreen(this);
-						break;
-				}
-
-				if (gameState != GameState.STACK) {
-					currentScreen.initialize();
-				}
-			}
-			previousGameState = gameState;
-
-			// call the update method for the currentScreen
-			currentScreen.update();
-		} while (previousGameState != gameState);
+		currentScreen.update();
 	}
 
 	@Override
@@ -86,42 +43,88 @@ public class ScreenCoordinator extends Screen {
 	}
 
 	/* RECURSIVE FUNCTIONALITY BELOW @author hle0 */
-
-	protected static class StackFrame {
-        public GameState state;
-        public Screen screen;
-
-        public StackFrame(GameState state, Screen screen) {
-            this.state = state;
-            this.screen = screen;
-        }
-    }
 	
-    protected ArrayDeque<StackFrame> stack = new ArrayDeque<>();
+    protected ArrayDeque<Screen> stack = new ArrayDeque<>();
 
+	/**
+	 * "Enter" a new screen from a starting screen, with the ability to resume the old one later.
+	 * @param screen the new screen to enter
+	 */
     public void push(Screen screen) {
-        this.stack.push(new StackFrame(this.gameState, this.currentScreen));
+        this.stack.addLast(this.currentScreen);
 
-        this.gameState = GameState.STACK;
         this.currentScreen = screen;
 		this.currentScreen.initialize();
+
+		if (this.currentScreen instanceof PlayLevelScreen) {
+			this.playLevelScreen = (PlayLevelScreen) this.currentScreen;
+		}
+
+		this.debugPrintStack("push");
     }
 
+	/**
+	 * Drop down one frame.
+	 * Be careful.
+	 */
     protected void drop() {
-        StackFrame frame = this.stack.pop();
-
-        this.gameState = frame.state;
-        this.currentScreen = frame.screen;
+        this.currentScreen = this.stack.removeLast();
     }
 
+	/**
+	 * Descend down the stack until reaching the desired Screen.
+	 * e.g., goes from the controls menu to the pause menu to the playlevel.
+	 */
+	public void dropUntil(Screen screen) {
+		while (this.currentScreen != screen) {
+			this.drop();
+		}
+
+		this.debugPrintStack("dropUntil");
+	}
+
+	/**
+	 * Exit a screen, going to the one before it. Warns if it is dropping more than one level (should not happen)
+	 * @param screen the screen to get rid of.
+	 */
     public void pop(Screen screen) {
         if (this.currentScreen != screen) {
             System.err.println("Warning; tried to pop a screen that wasn't the top screen.");
-            while (this.currentScreen != screen) {
-                this.drop();
-            }
+            this.dropUntil(screen);
         }
         
         this.drop();
+
+		this.debugPrintStack("pop");
     }
+
+	public void resumeLevel() {
+		this.dropUntil(this.playLevelScreen);
+	}
+
+	public void exitToMenu() {
+		this.dropUntil(this.mainMenuScreen);
+	}
+
+	private void debugPrintStack(String s) {
+		if (false) {
+			return;
+		}
+
+		System.out.println(s);
+
+		this.debugPrintStack();
+	}
+
+	private void debugPrintStack() {
+		Object[] screens = this.stack.toArray();
+
+		System.out.println("Screen stack contents:");
+
+		for (int i = 0; i < this.stack.size(); i++) {
+			System.out.printf("[%d] %s\n", i, screens[i].getClass().getName());
+		}
+
+		System.out.printf("[!!] %s\n", this.currentScreen.getClass().getName());
+	}
 }

--- a/src/Screens/AbstractMenuScreen.java
+++ b/src/Screens/AbstractMenuScreen.java
@@ -18,6 +18,18 @@ public abstract class AbstractMenuScreen extends Screen {
         public abstract void select(AbstractMenuScreen parent);
     }
 
+    public class CancelOption extends Option {
+        @Override
+        public String getText() {
+            return "BACK";
+        }
+
+        @Override
+        public void select(AbstractMenuScreen parent) {
+            parent.screenCoordinator.pop(parent);
+        }
+    }
+
     protected ScreenCoordinator screenCoordinator;
     protected int currentMenuItemHovered = 0; // current menu item being "hovered" over
     protected int menuItemSelected = -1;

--- a/src/Screens/AbstractMenuScreen.java
+++ b/src/Screens/AbstractMenuScreen.java
@@ -22,9 +22,7 @@ public abstract class AbstractMenuScreen extends Screen {
     protected int currentMenuItemHovered = 0; // current menu item being "hovered" over
     protected int menuItemSelected = -1;
     protected ArrayList<Option> options = new ArrayList<>();
-    protected Stopwatch keyTimer = new Stopwatch();
     protected int pointerLocationX, pointerLocationY;
-    protected KeyLocker keyLocker = new KeyLocker();
 
     protected static final Color COLOR_SELECTED = new Color(49, 207, 240);
     protected static final Color COLOR_UNSELECTED = new Color(255, 215, 0);
@@ -62,19 +60,15 @@ public abstract class AbstractMenuScreen extends Screen {
             o.spriteFont.setOutlineThickness(3);
         }
 
-        keyTimer.setWaitTime(200);
         menuItemSelected = -1;
-        keyLocker.lockKey(Key.SPACE);
     }
 
     @Override
     public void update() {
         // if down or up is pressed, change menu item "hovered" over (blue square in front of text will move along with currentMenuItemHovered changing)
-        if (Keyboard.isKeyDown(Key.DOWN) && keyTimer.isTimeUp()) {
-            keyTimer.reset();
+        if (GlobalKeyCooldown.Keys.DOWN.onceDown()) {
             currentMenuItemHovered++;
-        } else if (Keyboard.isKeyDown(Key.UP) && keyTimer.isTimeUp()) {
-            keyTimer.reset();
+        } else if (GlobalKeyCooldown.Keys.UP.onceDown()) {
             currentMenuItemHovered--;
         }
 
@@ -98,11 +92,9 @@ public abstract class AbstractMenuScreen extends Screen {
         pointerLocationY = 585 - 50 * this.getNumItems() + 50 * currentMenuItemHovered;
 
         // if space is pressed on menu item, change to appropriate screen based on which menu item was chosen
-        if (Keyboard.isKeyUp(Key.SPACE)) {
-            keyLocker.unlockKey(Key.SPACE);
-        }
+        GlobalKeyCooldown.Keys.SPACE.cancelIfUp();
 
-        if (!keyLocker.isKeyLocked(Key.SPACE) && Keyboard.isKeyDown(Key.SPACE)) {
+        if (GlobalKeyCooldown.Keys.SPACE.onceDown()) {
             menuItemSelected = currentMenuItemHovered;
             this.options.get(menuItemSelected).select(this);
         }

--- a/src/Screens/ControlsScreen.java
+++ b/src/Screens/ControlsScreen.java
@@ -15,18 +15,17 @@ public class ControlsScreen extends Screen {
     protected Screen previousScreen;
     protected PlayLevelScreen playLevelScreen;
     protected Map background;
-    protected KeyLocker keyLocker = new KeyLocker();
-    protected Stopwatch spaceTimer = new Stopwatch();
     protected SpriteFont[] controls = new SpriteFont[9];
-    protected GameState previousGameState;
 
     public ControlsScreen(ScreenCoordinator screenCoordinator) {
         this.screenCoordinator = screenCoordinator;
+        this.playLevelScreen = screenCoordinator.getPlayLevelScreen();
         initialize();
     }
 
     public ControlsScreen(PlayLevelScreen playLevelScreen) {
         this.playLevelScreen = playLevelScreen;
+        this.screenCoordinator = playLevelScreen.screenCoordinator;
         initialize();
     }
 
@@ -47,28 +46,16 @@ public class ControlsScreen extends Screen {
             controls[i].setOutlineColor(Color.black);
             controls[i].setOutlineThickness(3);
         }
-        spaceTimer.setWaitTime(50);
-        keyLocker.lockKey(Key.SPACE);
     }
 
     @Override
     public void update() {
         background.update(null);
 
-        if (Keyboard.isKeyUp(Key.SPACE) && spaceTimer.isTimeUp()) {
-            spaceTimer.reset();
-            keyLocker.unlockKey(Key.SPACE);
-        }
-
         //Checks whether or not playLevelScreen is null to go back to the proper screen
         //locking the key and checking if the spaceTimer is finished prevent the controls and pause menu from continually swapping between each other
-        if (!keyLocker.isKeyLocked(Key.SPACE) && Keyboard.isKeyDown(Key.SPACE) && spaceTimer.isTimeUp()) {
-            if (playLevelScreen != null) {
-                keyLocker.lockKey(Key.SPACE);
-                playLevelScreen.pause();
-            } else {
-                screenCoordinator.setGameState(GameState.MENU);
-            }
+        if (GlobalKeyCooldown.Keys.SPACE.onceDown()) {
+            screenCoordinator.pop(this);
         }
     }
 

--- a/src/Screens/CreditsScreen.java
+++ b/src/Screens/CreditsScreen.java
@@ -1,7 +1,6 @@
 package Screens;
 
 import Engine.*;
-import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.Map;
 import Maps.TitleScreenMap;
@@ -13,7 +12,6 @@ import java.awt.*;
 public class CreditsScreen extends Screen {
     protected ScreenCoordinator screenCoordinator;
     protected Map background;
-    protected KeyLocker keyLocker = new KeyLocker();
     protected SpriteFont creditsLabel;
     protected SpriteFont createdByLabel;
     protected SpriteFont returnInstructionsLabel;
@@ -30,19 +28,16 @@ public class CreditsScreen extends Screen {
         creditsLabel = new SpriteFont("Credits", 15, 35, "Times New Roman", 30, Color.white);
         createdByLabel = new SpriteFont("Created by Alex Thimineur", 130, 140, "Times New Roman", 20, Color.white);
         returnInstructionsLabel = new SpriteFont("Press Space to return to the menu", 20, 560, "Times New Roman", 30, Color.white);
-        keyLocker.lockKey(Key.SPACE);
     }
 
     public void update() {
         background.update(null);
 
-        if (Keyboard.isKeyUp(Key.SPACE)) {
-            keyLocker.unlockKey(Key.SPACE);
-        }
+        GlobalKeyCooldown.Keys.SPACE.cancelIfUp();
 
         // if space is pressed, go back to main menu
-        if (!keyLocker.isKeyLocked(Key.SPACE) && Keyboard.isKeyDown(Key.SPACE)) {
-            screenCoordinator.setGameState(GameState.MENU);
+        if (GlobalKeyCooldown.Keys.SPACE.onceDown()) {
+            screenCoordinator.pop(this);
         }
     }
 

--- a/src/Screens/HouseScreen.java
+++ b/src/Screens/HouseScreen.java
@@ -8,7 +8,6 @@ import Engine.Key;
 import Engine.KeyLocker;
 import Engine.Keyboard;
 import Engine.Screen;
-import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.*;
 import Maps.TestMap;
@@ -190,10 +189,6 @@ public class HouseScreen extends Screen {
 
 	public void resetLevel() {
 		initialize();
-	}
-
-	public void goBackToMenu() {
-		screenCoordinator.setGameState(GameState.MENU);
 	}
 
 	// This enum represents the different states this screen can be in

--- a/src/Screens/MenuScreen.java
+++ b/src/Screens/MenuScreen.java
@@ -1,7 +1,6 @@
 package Screens;
 
 import Engine.*;
-import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.Map;
 import Maps.TitleScreenMap;
@@ -22,7 +21,7 @@ public class MenuScreen extends AbstractMenuScreen {
 
         @Override
         public void select(AbstractMenuScreen parent) {
-            parent.screenCoordinator.setGameState(GameState.LEVEL);
+            parent.screenCoordinator.push(new PlayLevelScreen(parent.screenCoordinator));
         }
     }
 
@@ -34,7 +33,7 @@ public class MenuScreen extends AbstractMenuScreen {
 
         @Override
         public void select(AbstractMenuScreen parent) {
-            parent.screenCoordinator.setGameState(GameState.CONTROLS);
+            parent.screenCoordinator.push(new ControlsScreen(parent.screenCoordinator));
         }
     }
 
@@ -46,14 +45,14 @@ public class MenuScreen extends AbstractMenuScreen {
 
         @Override
         public void select(AbstractMenuScreen parent) {
-            parent.screenCoordinator.setGameState(GameState.CREDITS);
+            parent.screenCoordinator.push(new CreditsScreen(parent.screenCoordinator));
         }
     }
 
     public MenuScreen(ScreenCoordinator screenCoordinator) {
         super(screenCoordinator);
     }
-    
+
     @Override
     public void initialize() {
         background = new TitleScreenMap();

--- a/src/Screens/PauseScreen.java
+++ b/src/Screens/PauseScreen.java
@@ -1,12 +1,11 @@
 package Screens;
 
+import Engine.GlobalKeyCooldown;
 import Engine.GraphicsHandler;
 import Engine.Key;
 import Engine.KeyLocker;
 import Engine.Keyboard;
-import Engine.Screen;
 import Engine.ScreenManager;
-import Game.GameState;
 import Game.ScreenCoordinator;
 import SpriteFont.SpriteFont;
 import Utils.Stopwatch;
@@ -23,10 +22,7 @@ public class PauseScreen extends AbstractMenuScreen {
     protected SpriteFont resume;
     protected SpriteFont controls;
     protected SpriteFont saveAndQuit;
-    protected Stopwatch keyTimer = new Stopwatch();
-    protected Stopwatch spaceTimer = new Stopwatch();
     protected int pointerLocationX, pointerLocationY;
-    protected KeyLocker keyLocker = new KeyLocker();
     protected boolean isControlsOpen = false;
 
     public static class ResumeOption extends Option {
@@ -49,14 +45,7 @@ public class PauseScreen extends AbstractMenuScreen {
 
         @Override
         public void select(AbstractMenuScreen parent) {
-            //locking the key and checking if the spaceTimer is finished prevent the controls and pause menu from continually swapping between each other
-            if (!((PauseScreen) parent).spaceTimer.isTimeUp()) {
-                parent.menuItemSelected = -1;
-                return;
-            }
-
-            parent.keyLocker.lockKey(Key.SPACE);
-            ((PauseScreen) parent).playLevelScreen.controls();
+            parent.screenCoordinator.push(new ControlsScreen(parent.screenCoordinator));
         }
     }
 
@@ -69,7 +58,7 @@ public class PauseScreen extends AbstractMenuScreen {
         @Override
         public void select(AbstractMenuScreen parent) {
             // SAVE LOGIC GOES HERE
-            parent.screenCoordinator.setGameState(GameState.MENU);
+            parent.screenCoordinator.exitToMenu();
         }
     }
     
@@ -92,17 +81,6 @@ public class PauseScreen extends AbstractMenuScreen {
         pause = new SpriteFont("PAUSED", 10, 405, "Comic Sans", 30, Color.white);
         pause.setOutlineColor(Color.black);
         pause.setOutlineThickness(3);
-        spaceTimer.setWaitTime(50);
-    }
-
-    @Override
-    public void update() {
-        if (Keyboard.isKeyUp(Key.SPACE) && spaceTimer.isTimeUp()) {
-            spaceTimer.reset();
-            keyLocker.unlockKey(Key.SPACE);
-        }
-
-        super.update();
     }
 
     @Override

--- a/src/Screens/PauseScreen.java
+++ b/src/Screens/PauseScreen.java
@@ -7,6 +7,7 @@ import Engine.KeyLocker;
 import Engine.Keyboard;
 import Engine.ScreenManager;
 import Game.ScreenCoordinator;
+import Screens.SaveSlotScreen.SlotType;
 import SpriteFont.SpriteFont;
 import Utils.Stopwatch;
 import java.awt.*;
@@ -49,15 +50,38 @@ public class PauseScreen extends AbstractMenuScreen {
         }
     }
 
-    public static class SaveAndQuitOption extends Option {
+    public static class SaveOption extends Option {
         @Override
         public String getText() {
-            return "SAVE AND QUIT";
+            return "SAVE";
         }
 
         @Override
         public void select(AbstractMenuScreen parent) {
-            // SAVE LOGIC GOES HERE
+            parent.screenCoordinator.push(new SaveSlotScreen(parent.screenCoordinator, SlotType.SAVE));
+        }
+    }
+
+    public static class LoadOption extends Option {
+        @Override
+        public String getText() {
+            return "LOAD";
+        }
+
+        @Override
+        public void select(AbstractMenuScreen parent) {
+            parent.screenCoordinator.push(new SaveSlotScreen(parent.screenCoordinator, SlotType.LOAD));
+        }
+    }
+
+    public static class QuitOption extends Option {
+        @Override
+        public String getText() {
+            return "QUIT";
+        }
+
+        @Override
+        public void select(AbstractMenuScreen parent) {
             parent.screenCoordinator.exitToMenu();
         }
     }
@@ -72,13 +96,15 @@ public class PauseScreen extends AbstractMenuScreen {
     public void addOptions() {
         this.options.add(new ResumeOption());
         this.options.add(new ControlsOption());
-        this.options.add(new SaveAndQuitOption());
+        this.options.add(new SaveOption());
+        this.options.add(new LoadOption());
+        this.options.add(new QuitOption());
     }
 
     @Override
     public void initialize() {
         super.initialize();
-        pause = new SpriteFont("PAUSED", 10, 405, "Comic Sans", 30, Color.white);
+        pause = new SpriteFont("PAUSED", 10, 305, "Comic Sans", 30, Color.white);
         pause.setOutlineColor(Color.black);
         pause.setOutlineThickness(3);
     }

--- a/src/Screens/PlayLevelScreen.java
+++ b/src/Screens/PlayLevelScreen.java
@@ -8,7 +8,6 @@ import Engine.Key;
 import Engine.KeyLocker;
 import Engine.Keyboard;
 import Engine.Screen;
-import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.*;
 import Maps.TestMap;
@@ -25,8 +24,6 @@ public class PlayLevelScreen extends Screen {
 	protected PlayLevelScreenState playLevelScreenState;
 	protected WinScreen winScreen;
 	protected InventoryScreen inventoryScreen;
-	protected PauseScreen pauseScreen;
-	protected ControlsScreen controlsScreen;
 	protected FlagManager flagManager;
 	protected KeyLocker keyLocker = new KeyLocker();
 	protected boolean isInventoryOpen = false;
@@ -100,8 +97,6 @@ public class PlayLevelScreen extends Screen {
 		
 		winScreen = new WinScreen(this);
 		inventoryScreen = new InventoryScreen(this, playerInventory);
-		pauseScreen = new PauseScreen(this, screenCoordinator);
-		controlsScreen = new ControlsScreen(this);
 	}
 
 
@@ -122,12 +117,6 @@ public class PlayLevelScreen extends Screen {
 		case INVENTORY_OPEN:
 			inventoryScreen.update();
 			break;
-		case PAUSED:
-			pauseScreen.update();
-			break;
-		case CONTROLS: 
-			controlsScreen.update();
-			break;
 		}
 
 		// if flag is set at any point during gameplay, game is "won"
@@ -139,7 +128,7 @@ public class PlayLevelScreen extends Screen {
 			playLevelScreenState = PlayLevelScreenState.INVENTORY_OPEN;
 		}
 		if (Keyboard.isKeyDown(Pause_Key) && !keyLocker.isKeyLocked(Pause_Key)) {
-			playLevelScreenState = PlayLevelScreenState.PAUSED;
+			this.pause();
 		}
 		if(map.getFlagManager().isFlagSet("itemCollected")) {
 			Stack<Integer> itemsReceived = new Stack<Integer>();
@@ -177,12 +166,6 @@ public class PlayLevelScreen extends Screen {
 		case INVENTORY_OPEN:
 			inventoryScreen.draw(graphicsHandler);
 			break;
-		case PAUSED:
-			pauseScreen.draw(graphicsHandler);
-			break;
-		case CONTROLS:
-			controlsScreen.draw(graphicsHandler);
-			break;
 		}
 	}
 
@@ -199,14 +182,15 @@ public class PlayLevelScreen extends Screen {
 	}
 
 	public void pause() {
-		playLevelScreenState = PlayLevelScreenState.PAUSED;
+		screenCoordinator.push(new PauseScreen(this, screenCoordinator));
 	}
 
 	public void controls() {
-		playLevelScreenState = PlayLevelScreenState.CONTROLS;
+		screenCoordinator.push(new ControlsScreen(screenCoordinator));
 	}
 	
 	public void resumeLevel() {
+		this.screenCoordinator.resumeLevel();
 		playLevelScreenState = PlayLevelScreenState.RUNNING;
 	}
 
@@ -215,11 +199,11 @@ public class PlayLevelScreen extends Screen {
 	}
 
 	public void goBackToMenu() {
-		screenCoordinator.setGameState(GameState.MENU);
+		screenCoordinator.pop(this);
 	}
 
 	// This enum represents the different states this screen can be in
 	private enum PlayLevelScreenState {
-		RUNNING, LEVEL_COMPLETED, INVENTORY_OPEN, PAUSED, CONTROLS
+		RUNNING, LEVEL_COMPLETED, INVENTORY_OPEN
 	}
 }

--- a/src/Screens/SaveSlotScreen.java
+++ b/src/Screens/SaveSlotScreen.java
@@ -1,0 +1,112 @@
+package Screens;
+
+import java.io.IOException;
+
+import Engine.GraphicsHandler;
+import Game.ScreenCoordinator;
+import SpriteFont.SpriteFont;
+
+import java.awt.*;
+
+public class SaveSlotScreen extends AbstractMenuScreen {
+    protected static abstract class SlotOption extends Option {
+        public int slot;
+
+        public SlotOption(int slot) {
+            this.slot = slot;
+        }
+
+        @Override
+        public String getText() {
+            return String.format("Slot %d", this.slot + 1);
+        }
+
+        public String getFilename() {
+            return String.format("%d.save", this.slot);
+        }
+    }
+
+    public static class SaveOption extends SlotOption {
+        public SaveOption(int slot) {
+            super(slot);
+        }
+
+        @Override
+        public void select(AbstractMenuScreen parent) {
+            PlayLevelScreen playLevelScreen = parent.screenCoordinator.getPlayLevelScreen();
+            
+            playLevelScreen.flagManager.updateFrom(playLevelScreen.player);
+
+            try {
+                playLevelScreen.flagManager.saveToSlot(this.slot);
+            } catch (IOException exception) {
+                exception.printStackTrace();
+                // TODO: warn user?
+            }
+
+            parent.screenCoordinator.pop(parent);
+        }
+    }
+
+    public static class LoadOption extends SlotOption {
+        public LoadOption(int slot) {
+            super(slot);
+        }
+
+        @Override
+        public void select(AbstractMenuScreen parent) {
+            PlayLevelScreen playLevelScreen = parent.screenCoordinator.getPlayLevelScreen();
+            
+            try {
+                playLevelScreen.flagManager.loadFromSlot(this.slot);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+                // TODO: warn user?
+            }
+
+            playLevelScreen.flagManager.updateTo(playLevelScreen.player);
+
+            parent.screenCoordinator.pop(parent);
+        }
+    }
+
+    public SlotType type;
+    public SpriteFont titleText;
+
+    public static enum SlotType {
+        SAVE, LOAD
+    };
+
+    public SaveSlotScreen(ScreenCoordinator coordinator, SlotType type) {
+        super(coordinator);
+        this.type = type;
+    }
+
+    @Override
+    public void addOptions() {
+        for (int i = 0; i < 3; i++) {
+            switch (this.type) {
+                case SAVE:
+                    this.options.add(new SaveOption(i));
+                    break;
+                case LOAD:
+                    this.options.add(new LoadOption(i));
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void initialize() {
+        titleText = new SpriteFont(this.type == SlotType.SAVE ? "SAVE TO SLOT" : "LOAD FROM SLOT", 10, 405, "Comic Sans", 30, Color.white);
+        titleText.setOutlineColor(Color.black);
+        titleText.setOutlineThickness(3);
+        super.initialize();
+    }
+
+    @Override
+    public void draw(GraphicsHandler graphicsHandler) {
+        titleText.draw(graphicsHandler);
+        super.draw(graphicsHandler);
+    }
+}

--- a/src/Screens/SaveSlotScreen.java
+++ b/src/Screens/SaveSlotScreen.java
@@ -94,11 +94,13 @@ public class SaveSlotScreen extends AbstractMenuScreen {
                     break;
             }
         }
+
+        this.options.add(new CancelOption());
     }
 
     @Override
     public void initialize() {
-        titleText = new SpriteFont(this.type == SlotType.SAVE ? "SAVE TO SLOT" : "LOAD FROM SLOT", 10, 405, "Comic Sans", 30, Color.white);
+        titleText = new SpriteFont(this.type == SlotType.SAVE ? "SAVE TO SLOT" : "LOAD FROM SLOT", 10, 355, "Comic Sans", 30, Color.white);
         titleText.setOutlineColor(Color.black);
         titleText.setOutlineThickness(3);
         super.initialize();

--- a/src/Scripts/TestMap/EnterHouseScript.java
+++ b/src/Scripts/TestMap/EnterHouseScript.java
@@ -1,6 +1,5 @@
 package Scripts.TestMap;
 
-import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.Script;
 import Level.ScriptState;


### PR DESCRIPTION
This branch changes several things:
- The ScreenCoordinator is now recursive, or, more accurately, it has a stack. Screens are no longer nested through each other, but through the coordinator. The coordinator has a stack, where screens are pushed onto when they are opened, and then screens pop themselves off of the top of the stack when they are exiting. Only the top screen is ever rendered, but the state of the screens below them (e.g. the main menu) are kept safe and not reinstantiated every time they are opened. This also means that any screen can be opened from any other screen, and we don't have to worry about e.g. the controls screen exiting to the main menu screen instead of the pause menu.
- GameState is removed, since screens are now instantiated directly instead of through a transition in GameState.
- There is now a global time-based key locker class for menus, GlobalKeyCooldown. This should be shared by all menus to ensure that they share a common cooldown for keyboard inputs.
- **Update dbd1ec0**: There is a save and load menu on the pause screen
- **Update 677ac1a**: There is a cancel button on the save/load menu